### PR TITLE
Simplify deployment structure - GitHub handles project page subdirect…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -211,49 +211,17 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           
-          # Determine deployment path
-          REPO_NAME="${{ github.event.repository.name }}"
-          OWNER="${{ github.repository_owner }}"
+          # Remove old files (but keep pr-preview directory and CNAME if exists)
+          find . -maxdepth 1 -type f ! -name 'CNAME' -delete
+          find . -maxdepth 1 -type d ! -name '.git' ! -name '.' ! -name 'pr-preview' ! -name 'build' -exec rm -rf {} +
           
-          # Check for CNAME file in gh-pages to determine custom domain
-          HAS_CUSTOM_DOMAIN=false
-          if [ -f "CNAME" ]; then
-            HAS_CUSTOM_DOMAIN=true
-          fi
-          
-          # For project pages without custom domain, we need to deploy to a subdirectory
-          if [[ "${HAS_CUSTOM_DOMAIN}" == "true" ]] || [[ "${REPO_NAME}" == "${OWNER}.github.io" ]]; then
-            # Custom domain or user/org site - deploy to root
-            echo "Deploying to root directory"
-            
-            # Remove old files (but keep pr-preview directory and any project subdirectories)
-            find . -maxdepth 1 -type f ! -name 'CNAME' -delete
-            find . -maxdepth 1 -type d ! -name '.git' ! -name '.' ! -name 'pr-preview' ! -name 'build' -exec rm -rf {} +
-            
-            # Copy new build files to root
-            if [ -d "./build" ] && [ "$(ls -A ./build)" ]; then
-              cp -R ./build/* ./
-              rm -rf ./build
-            else
-              echo "Error: Build directory is empty or doesn't exist"
-              exit 1
-            fi
+          # Copy new build files to root
+          if [ -d "./build" ] && [ "$(ls -A ./build)" ]; then
+            cp -R ./build/* ./
+            rm -rf ./build
           else
-            # Project pages site - deploy to project subdirectory
-            echo "Deploying to project subdirectory: ${REPO_NAME}"
-            
-            # Create/update project directory
-            rm -rf "${REPO_NAME}"
-            mkdir -p "${REPO_NAME}"
-            
-            # Copy new build files to project directory
-            if [ -d "./build" ] && [ "$(ls -A ./build)" ]; then
-              cp -R ./build/* "${REPO_NAME}/"
-              rm -rf ./build
-            else
-              echo "Error: Build directory is empty or doesn't exist"
-              exit 1
-            fi
+            echo "Error: Build directory is empty or doesn't exist"
+            exit 1
           fi
           
           # Add .nojekyll file to prevent Jekyll processing
@@ -296,25 +264,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           
-          # Determine if this is a project pages site or custom domain/user site
-          REPO_NAME="${{ github.event.repository.name }}"
-          OWNER="${{ github.repository_owner }}"
+          # PR previews always go in pr-preview directory at root
           PR_NUMBER="${{ github.event.pull_request.number }}"
-          
-          # Check for CNAME file in gh-pages to determine custom domain
-          HAS_CUSTOM_DOMAIN=false
-          if [ -f "CNAME" ]; then
-            HAS_CUSTOM_DOMAIN=true
-          fi
-          
-          # Determine preview directory path
-          if [[ "${HAS_CUSTOM_DOMAIN}" == "true" ]] || [[ "${REPO_NAME}" == "${OWNER}.github.io" ]]; then
-            # Custom domain or user/org site - use root-level pr-preview
-            PREVIEW_DIR="pr-preview/pr-${PR_NUMBER}"
-          else
-            # Project pages site - use project-specific path
-            PREVIEW_DIR="${REPO_NAME}/pr-preview/pr-${PR_NUMBER}"
-          fi
+          PREVIEW_DIR="pr-preview/pr-${PR_NUMBER}"
           
           echo "Deploying to preview directory: ${PREVIEW_DIR}"
           
@@ -431,25 +383,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           
-          # Determine if this is a project pages site or custom domain/user site
-          REPO_NAME="${{ github.event.repository.name }}"
-          OWNER="${{ github.repository_owner }}"
+          # PR previews are always in pr-preview directory at root
           PR_NUMBER="${{ github.event.pull_request.number }}"
-          
-          # Check for CNAME file in gh-pages to determine custom domain
-          HAS_CUSTOM_DOMAIN=false
-          if [ -f "CNAME" ]; then
-            HAS_CUSTOM_DOMAIN=true
-          fi
-          
-          # Determine preview directory path
-          if [[ "${HAS_CUSTOM_DOMAIN}" == "true" ]] || [[ "${REPO_NAME}" == "${OWNER}.github.io" ]]; then
-            # Custom domain or user/org site - use root-level pr-preview
-            PREVIEW_DIR="pr-preview/pr-${PR_NUMBER}"
-          else
-            # Project pages site - use project-specific path
-            PREVIEW_DIR="${REPO_NAME}/pr-preview/pr-${PR_NUMBER}"
-          fi
+          PREVIEW_DIR="pr-preview/pr-${PR_NUMBER}"
           
           echo "Removing preview directory: ${PREVIEW_DIR}"
           


### PR DESCRIPTION
…ories

- Remove manual subdirectory creation for project pages
- GitHub automatically serves project pages from /<repo-name>/ URL path
- All deployments now go to root of gh-pages branch
- PR previews always go to /pr-preview/pr-{number}/ at root
- Simplified deployment logic across all jobs