### PR TITLE
Fix PR preview paths - remove subfolder logic

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,25 +67,15 @@ jobs:
       - name: Set BASE_URL for PR preview
         if: github.event_name == 'pull_request_target' && github.event.action != 'closed'
         run: |
-          # Check if custom domain exists
+          # PR previews always use the same path structure
+          echo "BASE_URL=/pr-preview/pr-${{ github.event.pull_request.number }}/" >> $GITHUB_ENV
+          
+          # Set SITE_URL based on custom domain or GitHub Pages
           if [[ "${{ steps.check-domain.outputs.has_custom_domain }}" == "true" ]]; then
-            # Custom domain setup
-            echo "BASE_URL=/pr-preview/pr-${{ github.event.pull_request.number }}/" >> $GITHUB_ENV
             echo "SITE_URL=https://${{ steps.check-domain.outputs.custom_domain }}" >> $GITHUB_ENV
           else
-            # Default GitHub Pages setup
-            REPO_NAME="${{ github.event.repository.name }}"
-            OWNER="${{ github.repository_owner }}"
-            
-            if [[ "${REPO_NAME}" == "${OWNER}.github.io" ]]; then
-              # User/org pages site
-              echo "BASE_URL=/pr-preview/pr-${{ github.event.pull_request.number }}/" >> $GITHUB_ENV
-              echo "SITE_URL=https://${OWNER}.github.io" >> $GITHUB_ENV
-            else
-              # Project pages site
-              echo "BASE_URL=/${REPO_NAME}/pr-preview/pr-${{ github.event.pull_request.number }}/" >> $GITHUB_ENV
-              echo "SITE_URL=https://${OWNER}.github.io" >> $GITHUB_ENV
-            fi
+            # GitHub automatically serves project pages from /{repo-name}/ subdirectory
+            echo "SITE_URL=https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}" >> $GITHUB_ENV
           fi
 
       - name: Set BASE_URL for production
@@ -170,25 +160,15 @@ jobs:
 
       - name: Set BASE_URL for PR preview
         run: |
-          # Check if custom domain exists
+          # PR previews always use the same path structure
+          echo "BASE_URL=/pr-preview/pr-${{ github.event.pull_request.number }}/" >> $GITHUB_ENV
+          
+          # Set SITE_URL based on custom domain or GitHub Pages
           if [[ "${{ steps.check-domain.outputs.has_custom_domain }}" == "true" ]]; then
-            # Custom domain setup
-            echo "BASE_URL=/pr-preview/pr-${{ github.event.pull_request.number }}/" >> $GITHUB_ENV
             echo "SITE_URL=https://${{ steps.check-domain.outputs.custom_domain }}" >> $GITHUB_ENV
           else
-            # Default GitHub Pages setup
-            REPO_NAME="${{ github.event.repository.name }}"
-            OWNER="${{ github.repository_owner }}"
-            
-            if [[ "${REPO_NAME}" == "${OWNER}.github.io" ]]; then
-              # User/org pages site
-              echo "BASE_URL=/pr-preview/pr-${{ github.event.pull_request.number }}/" >> $GITHUB_ENV
-              echo "SITE_URL=https://${OWNER}.github.io" >> $GITHUB_ENV
-            else
-              # Project pages site
-              echo "BASE_URL=/${REPO_NAME}/pr-preview/pr-${{ github.event.pull_request.number }}/" >> $GITHUB_ENV
-              echo "SITE_URL=https://${OWNER}.github.io" >> $GITHUB_ENV
-            fi
+            # GitHub automatically serves project pages from /{repo-name}/ subdirectory
+            echo "SITE_URL=https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}" >> $GITHUB_ENV
           fi
 
       - name: Build Docusaurus


### PR DESCRIPTION
- PR previews now always use /pr-preview/pr-{number}/ regardless of project type
- Both regular and fork PR builds use the same consistent path structure
- This fixes the issue where PR previews were built with wrong baseUrl
- GitHub automatically handles serving project pages from /{repo-name}/ subdirectory