### PR TITLE
Fix PR preview checkout to use correct commit

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,6 +38,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # For PR builds, checkout the PR head commit
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}
 
       - name: Setup Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
- For pull_request_target events, explicitly checkout PR head SHA
- This ensures PR previews show the actual PR content, not base branch
- Fixes issue where PR #7 showed default content instead of 'This is a test'