### PR TITLE
Fix CNAME detection by fetching all branches in workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,8 @@ jobs:
         with:
           # For PR builds, checkout the PR head commit
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}
+          # Fetch all history to access other branches (needed for CNAME detection)
+          fetch-depth: 0
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -152,6 +154,8 @@ jobs:
         with:
           # Explicitly checkout the PR head commit to ensure we're building the PR's code
           ref: ${{ github.event.pull_request.head.sha }}
+          # Fetch all history to access other branches (needed for CNAME detection)
+          fetch-depth: 0
 
       - name: Setup Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
The workflow was failing to detect the CNAME file in gh-pages branch because the checkout action only fetches the current branch by default. Adding fetch-depth: 0 ensures all branches are fetched, allowing git show origin/gh-pages:CNAME to work correctly.